### PR TITLE
feat: Re-`claim` delegations during client setup

### DIFF
--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -31,6 +31,7 @@ export function useDatamodel ({ servicePrincipal, connection }: DatamodelProps):
       setEvents(events)
       setAccounts(Object.values(client.accounts()))
       setSpaces(client.spaces())
+      await client.capability.access.claim()
     },
     [servicePrincipal, connection]
   )


### PR DESCRIPTION
The rest of https://github.com/storacha/project-tracking/issues/125. This along with [generating the space delegations on the fly during `access/claim`](https://github.com/storacha/w3up/pull/1555) will make new spaces appear on the page without logging out.

---

If the client is restored from local storage, it may be out of date. This fetches the latest delegations from the server and updates the client. This makes loading the client from local storage a stale-while-revalidate operation.