### PR TITLE
fix: add missing receiptsEndpoint to client instantiation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export interface ContextActions {
 
 export interface CreateClientOptions extends ServiceConfig {
   events?: EventTarget
+  receiptsEndpoint?: URL
 }
 
 /**
@@ -72,6 +73,6 @@ export async function createClient (
   const events = options?.events ?? new EventTarget()
   const store = new IndexedDBEventDispatcherStore(dbName, events)
   const serviceConf = createServiceConf(options)
-  const client = await createW3UPClient({ store, serviceConf })
+  const client = await createW3UPClient({ store, serviceConf, receiptsEndpoint: options?.receiptsEndpoint })
   return { client, events, store }
 }

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -8,7 +8,9 @@ import type {
 import { useState, useEffect, useCallback } from 'react'
 import { STORE_SAVE_EVENT, createClient } from '@w3ui/core'
 
-export type DatamodelProps = ServiceConfig
+export type DatamodelProps = ServiceConfig & {
+  receiptsEndpoint?: URL
+}
 
 export interface Datamodel {
   client?: Client
@@ -17,7 +19,7 @@ export interface Datamodel {
   logout: () => Promise<void>
 }
 
-export function useDatamodel ({ servicePrincipal, connection }: DatamodelProps): Datamodel {
+export function useDatamodel ({ servicePrincipal, connection, receiptsEndpoint }: DatamodelProps): Datamodel {
   const [client, setClient] = useState<Client>()
   const [events, setEvents] = useState<EventTarget>()
   const [accounts, setAccounts] = useState<Account[]>([])
@@ -26,7 +28,7 @@ export function useDatamodel ({ servicePrincipal, connection }: DatamodelProps):
   // update this function any time servicePrincipal or connection change
   const setupClient = useCallback(
     async (): Promise<void> => {
-      const { client, events } = await createClient({ servicePrincipal, connection })
+      const { client, events } = await createClient({ servicePrincipal, connection, receiptsEndpoint })
       setClient(client)
       setEvents(events)
       setAccounts(Object.values(client.accounts()))

--- a/packages/react/src/providers/Provider.tsx
+++ b/packages/react/src/providers/Provider.tsx
@@ -33,6 +33,7 @@ export const Context = createContext<ContextValue>(
 
 export interface ProviderProps extends ServiceConfig {
   children?: ReactNode
+  receiptsEndpoint?: URL
 }
 
 /**
@@ -41,9 +42,10 @@ export interface ProviderProps extends ServiceConfig {
 export function Provider ({
   children,
   servicePrincipal,
-  connection
+  connection,
+  receiptsEndpoint
 }: ProviderProps): ReactNode {
-  const { client, accounts, spaces, logout } = useDatamodel({ servicePrincipal, connection })
+  const { client, accounts, spaces, logout } = useDatamodel({ servicePrincipal, connection, receiptsEndpoint })
   return (
     <Context.Provider value={[{ client, accounts, spaces }, { logout }]}>
       {children}


### PR DESCRIPTION
## Description

This PR adds the `receiptsEndpoint` to the `w3up-client` instantiation.

## Motivation

Uploading in staging is currently broken. The console shows an error when attempting to retrieve the receipt.

The receipts endpoint being used for staging is incorrect due to a missing configuration. This causes the value to default to a hardcoded production endpoint.